### PR TITLE
[Automated] spring-boot-starter-test from 1.2.6 to 1.2.9

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -28,7 +28,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <version>1.2.6</version>
+      <version>1.2.9</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Update report
- artifactId: spring-boot-starter-test
- artifactVersion: 1.2.9